### PR TITLE
added hpfeeds support for mailoney

### DIFF
--- a/mailoney.py
+++ b/mailoney.py
@@ -16,9 +16,15 @@ import modules.schizo_open_relay
 # parse the command line arguments to set the variables for the server
 parser = argparse.ArgumentParser(description="Command line arguments")
 parser.add_argument('-i',action='store', metavar='<ip address>', default='0.0.0.0', help='The IP address to listen on')
-parser.add_argument('-p',action='store', metavar='<port>', default='25', help='The port to listen on')
-parser.add_argument('-s',action='store', metavar='mailserver', required=True, help='A Name that\'ll show up as the mail server name')
+parser.add_argument('-p',action='store', metavar='<port>',  default='25', help='The port to listen on')
+parser.add_argument('-s',action='store', metavar='mailserver', default=os.environ.get('MAILSERVER_NAME', None), help='A Name that\'ll show up as the mail server name')
 parser.add_argument('-t',action='store', choices=['open_relay', 'postfix_creds', 'schizo_open_relay'], required=True, help='honeypot type')
+parser.add_argument('-hpfserver', action='store', metavar='<hpfeeds-server>', default=os.environ.get('HPFEEDS_SERVER', None), help='HPFeeds Server')
+parser.add_argument('-hpfport', action='store', metavar='<hpfeeds-port>', default=os.environ.get('HPFEEDS_PORT', None), help='HPFeeds Port')
+parser.add_argument('-hpfident', action='store', metavar='<hpfeeds-ident>', default=os.environ.get('HPFEEDS_IDENT', None), help='HPFeeds Username')
+parser.add_argument('-hpfsecret', action='store', metavar='<hpfeeds-secret>', default=os.environ.get('HPFEEDS_SECRET', None), help='HPFeeds Secret')
+parser.add_argument('-hpfchannelprefix', action='store', metavar='<hpfeeds-channel-prefix>', default=os.environ.get('HPFEEDS_CHANNELPREFIX', None), help='HPFeeds Channel Prefix')
+
 args = parser.parse_args()
 
 # set the IP address variables
@@ -26,23 +32,34 @@ bind_ip = args.i
 bind_port = int(args.p)
 srvname = args.s
 
-banner = ('''
-****************************************************************
-\tMailoney - A Simple SMTP Honeypot - Version: {}
-****************************************************************
-'''.format(__version__))
+# set hpfeeds related data
+hpfeeds_server=""
+hpfeeds_port=int(args.hpfport)
+hpfeeds_ident=args.hpfident
+hpfeeds_secret=args.hpfsecret
+hpfeeds_prefix=args.hpfchannelprefix
 
-# create log directory (thanks @Bifrozt_Dev)
-if not os.path.isdir('logs'):
-        os.mkdir('logs')
 
-# call server type module, based on parsed arguments
-if args.t == 'postfix_creds':
-    modules.postfix_creds.pfserver()
-elif args.t == 'open_relay':
-    modules.open_relay.or_module()
-elif args.t == 'schizo_open_relay':
-    modules.schizo_open_relay.module()
-else:
-    print 'I don\'t know what this module is...Exiting...\r\n'
+if __name__ == "__main__":
+
+    banner = ('''
+    ****************************************************************
+    \tMailoney - A Simple SMTP Honeypot - Version: {}
+    ****************************************************************
+    '''.format(__version__))
+    print banner
+
+    # create log directory (thanks @Bifrozt_Dev)
+    if not os.path.isdir('logs'):
+            os.mkdir('logs')
+
+    # call server type module, based on parsed arguments
+    if args.t == 'postfix_creds':
+        modules.postfix_creds.pfserver()
+    elif args.t == 'open_relay':
+        modules.open_relay.or_module()
+    elif args.t == 'schizo_open_relay':
+        modules.schizo_open_relay.module()
+    else:
+        print 'I don\'t know what this module is...Exiting...\r\n'
 

--- a/mailoney.py
+++ b/mailoney.py
@@ -7,7 +7,7 @@ add some nice comments here
 
 import argparse
 import os
-
+import hpfeeds
 import modules.postfix_creds
 import modules.open_relay
 import modules.schizo_open_relay
@@ -32,12 +32,26 @@ bind_ip = args.i
 bind_port = int(args.p)
 srvname = args.s
 
-# set hpfeeds related data
-hpfeeds_server=""
-hpfeeds_port=int(args.hpfport)
-hpfeeds_ident=args.hpfident
-hpfeeds_secret=args.hpfsecret
-hpfeeds_prefix=args.hpfchannelprefix
+
+
+def connect_hpfeeds():
+    # set hpfeeds related data
+    hpfeeds_server = args.hpfserver
+    hpfeeds_port = int(args.hpfport)
+    hpfeeds_ident = args.hpfident
+    hpfeeds_secret = args.hpfsecret
+    hpfeeds_prefix = args.hpfchannelprefix
+
+    if hpfeeds_server and hpfeeds_port and hpfeeds_ident and hpfeeds_secret and hpfeeds_prefix:
+        try:
+            hpc = hpfeeds.new(hpfeeds_server, hpfeeds_port, hpfeeds_ident, hpfeeds_secret)
+            return hpc, hpfeeds_prefix
+        except (hpfeeds.FeedException, socket.error, hpfeeds.Disconnect), e:
+            print "not successful"
+            logger.warn('Exception while connecting: {0}'.format(e))
+    return False, False
+
+
 
 
 if __name__ == "__main__":

--- a/mailoney.py
+++ b/mailoney.py
@@ -19,6 +19,7 @@ parser.add_argument('-i',action='store', metavar='<ip address>', default='0.0.0.
 parser.add_argument('-p',action='store', metavar='<port>',  default='25', help='The port to listen on')
 parser.add_argument('-s',action='store', metavar='mailserver', default=os.environ.get('MAILSERVER_NAME', None), help='A Name that\'ll show up as the mail server name')
 parser.add_argument('-t',action='store', choices=['open_relay', 'postfix_creds', 'schizo_open_relay'], required=True, help='honeypot type')
+parser.add_argument('-logpath',action='store', metavar='<logpath>',  default=os.environ.get('LOGPATH'), help='path for file logging')
 parser.add_argument('-hpfserver', action='store', metavar='<hpfeeds-server>', default=os.environ.get('HPFEEDS_SERVER', None), help='HPFeeds Server')
 parser.add_argument('-hpfport', action='store', metavar='<hpfeeds-port>', default=os.environ.get('HPFEEDS_PORT', None), help='HPFeeds Port')
 parser.add_argument('-hpfident', action='store', metavar='<hpfeeds-ident>', default=os.environ.get('HPFEEDS_IDENT', None), help='HPFeeds Username')
@@ -27,12 +28,15 @@ parser.add_argument('-hpfchannelprefix', action='store', metavar='<hpfeeds-chann
 
 args = parser.parse_args()
 
+# set own logpath
+logpath="./logs/"
+if args.logpath:
+    logpath=args.logpath
+
 # set the IP address variables
 bind_ip = args.i
 bind_port = int(args.p)
 srvname = args.s
-
-
 
 def connect_hpfeeds():
     # set hpfeeds related data
@@ -52,8 +56,6 @@ def connect_hpfeeds():
     return False, False
 
 
-
-
 if __name__ == "__main__":
 
     banner = ('''
@@ -64,8 +66,8 @@ if __name__ == "__main__":
     print banner
 
     # create log directory (thanks @Bifrozt_Dev)
-    if not os.path.isdir('logs'):
-            os.mkdir('logs')
+    if not os.path.isdir(logpath):
+            os.mkdir(logpath)
 
     # call server type module, based on parsed arguments
     if args.t == 'postfix_creds':

--- a/mailoney.py
+++ b/mailoney.py
@@ -51,7 +51,7 @@ def connect_hpfeeds():
             hpc = hpfeeds.new(hpfeeds_server, hpfeeds_port, hpfeeds_ident, hpfeeds_secret)
             return hpc, hpfeeds_prefix
         except (hpfeeds.FeedException, socket.error, hpfeeds.Disconnect), e:
-            print "not successful"
+            print "hpfeeds connection not successful"
             logger.warn('Exception while connecting: {0}'.format(e))
     return False, False
 

--- a/modules/schizo_open_relay.py
+++ b/modules/schizo_open_relay.py
@@ -13,13 +13,13 @@ import threading
 import asyncore
 import asynchat
 
-import hpfeeds
 import json
 
 sys.path.append("../")
 import mailoney
 
 output_lock = threading.RLock()
+hpc,hpfeeds_prefix = mailoney.connect_hpfeeds()
 
 def log_to_file(file_path, ip, port, data):
     with output_lock:
@@ -29,24 +29,10 @@ def log_to_file(file_path, ip, port, data):
             f.write(message + "\n")
 
 def log_to_hpfeeds(channel, data):
-    if mailoney.hpfeeds_server:
-        try:
-            hpc = hpfeeds.new(mailoney.hpfeeds_server, mailoney.hpfeeds_port, mailoney.hpfeeds_ident, mailoney.hpfeeds_secret)
-        except hpfeeds.FeedException, e:
-            return False
-
-        message = data
-        hpfchannel=mailoney.hpfeeds_prefix+"."+channel
-
-        hpc.publish(hpfchannel, message)
-
-        emsg = hpc.wait()
-
-        if emsg:
-            print("[*] hpfeeds: ", "HPFeeds Error (%s)" % format(emsg))
-            return False
-
-        return True
+        if hpc:
+            message = data
+            hpfchannel=hpfeeds_prefix+"."+channel
+            hpc.publish(hpfchannel, message)
 
 
 
@@ -345,7 +331,6 @@ def module():
 
 
     def run():
-
         honeypot = SchizoOpenRelay((mailoney.bind_ip, mailoney.bind_port), None)
         print '[*] Mail Relay listening on {}:{}'.format(mailoney.bind_ip, mailoney.bind_port)
         try:

--- a/modules/schizo_open_relay.py
+++ b/modules/schizo_open_relay.py
@@ -34,8 +34,6 @@ def log_to_hpfeeds(channel, data):
             hpfchannel=hpfeeds_prefix+"."+channel
             hpc.publish(hpfchannel, message)
 
-
-
 def process_packet_for_shellcode(packet, ip, port):
     if libemu is None:
         return
@@ -43,10 +41,10 @@ def process_packet_for_shellcode(packet, ip, port):
     r = emulator.test(packet)
     if r is not None:
         # we have shellcode
-        log_to_file("logs/shellcode.log", ip, port, "We have some shellcode")
-        #log_to_file("logs/shellcode.log", ip, port, emulator.emu_profile_output)
-        #log_to_hpfeeds("shellcode", ip, port, emulator.emu_profile_output)
-        log_to_file("logs/shellcode.log", ip, port, packet)
+        log_to_file(mailoney.logpath+"/shellcode.log", ip, port, "We have some shellcode")
+        #log_to_file(mailoney.logpath+"/shellcode.log", ip, port, emulator.emu_profile_output)
+        #log_to_hpfeeds("/shellcode", ip, port, emulator.emu_profile_output)
+        log_to_file(mailoney.logpath+"/shellcode.log", ip, port, packet)
         log_to_hpfeeds("shellcode",  json.dumps({ "Timestamp":format(time.time()), "ServerName": self.__fqdn, "SrcIP": self.__addr[0], "SrcPort": self.__addr[1],"Shellcode" :packet}))
 
 
@@ -103,7 +101,7 @@ class SMTPChannel(asynchat.async_chat):
     # Implementation of base class abstract method
     def found_terminator(self):
         line = EMPTYSTRING.join(self.__line)
-        log_to_file("logs/commands.log", self.__addr[0], self.__addr[1], line.encode('string-escape'))
+        log_to_file(mailoney.logpath+"/commands.log", self.__addr[0], self.__addr[1], line.encode('string-escape'))
         log_to_hpfeeds("commands",  json.dumps({ "Timestamp":format(time.time()), "ServerName": self.__fqdn, "SrcIP": self.__addr[0], "SrcPort": self.__addr[1],"Commmand" : line.encode('string-escape')}))
 
         #print >> DEBUGSTREAM, 'Data:', repr(line)
@@ -312,12 +310,12 @@ def module():
 
         def process_message(self, peer, mailfrom, rcpttos, data):
             #setup the Log File
-            log_to_file("logs/mail.log", peer[0], peer[1], '')
-            log_to_file("logs/mail.log", peer[0], peer[1], '*' * 50)
-            log_to_file("logs/mail.log", peer[0], peer[1], 'Mail from: {0}'.format(mailfrom))
-            log_to_file("logs/mail.log", peer[0], peer[1], 'Mail to: {0}'.format(", ".join(rcpttos)))
-            log_to_file("logs/mail.log", peer[0], peer[1], 'Data:')
-            log_to_file("logs/mail.log", peer[0], peer[1], data)
+            log_to_file(mailoney.logpath+"/mail.log", peer[0], peer[1], '')
+            log_to_file(mailoney.logpath+"/mail.log", peer[0], peer[1], '*' * 50)
+            log_to_file(mailoney.logpath+"/mail.log", peer[0], peer[1], 'Mail from: {0}'.format(mailfrom))
+            log_to_file(mailoney.logpath+"/mail.log", peer[0], peer[1], 'Mail to: {0}'.format(", ".join(rcpttos)))
+            log_to_file(mailoney.logpath+"/mail.log", peer[0], peer[1], 'Data:')
+            log_to_file(mailoney.logpath+"/mail.log", peer[0], peer[1], data)
 
             loghpfeeds = {}
             loghpfeeds['ServerName'] = mailoney.srvname


### PR DESCRIPTION
I added hpfeeds support for mailoney. 

If **_hpfeeds_** shall be enabled, you must set either
a) the following environment variables 
`HPFEEDS_SERVER, HPFEEDS_PORT, HPFEEDS_IDENT, HPFEEDS_SECRET, HPFEEDS_CHANNELPREFIX`
_or_
b) add corresponding arguments `-hpfserver, -hpfport, -hpfident, -hpfsecret, -hpfchannelprefix `

In case they are not set, it will behave as before and only log locally.

The **_mailserver name_** can now also be set via env variable `MAILSERVER_NAME` / `-s`

Further a **_logpath_** (`-logpath  `/ env: `LOGPATH`) is introduced, so you can choose to redirect the logging to another location, eg. to another partition.

The logging to hpfeeds is done in json for easier processing. 

Only implemented it for `schizo_open_relay`, as I think this is the most useful. However, you can easily port it to the other ones, too. 

Hope you find it useful and accept the pull request. Cheers.