### PR TITLE
fix: [smtp] When default options are not set the server crashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 __pycache__
+logs/

--- a/modules/open_relay.py
+++ b/modules/open_relay.py
@@ -17,7 +17,7 @@ def or_module():
 
     class OpenRelay(SMTPServer):
 
-        def process_message(self, peer, mailfrom, rcpttos, data):
+        def process_message(self, peer, mailfrom, rcpttos, data, mail_options=None,rcpt_options=None):
             #setup the Log File
             if os.path.exists('logs/mail.log'):
                 logfile = open('logs/mail.log', 'a')

--- a/modules/schizo_open_relay.py
+++ b/modules/schizo_open_relay.py
@@ -289,7 +289,7 @@ class SMTPServer(asyncore.dispatcher):
         self.close()
 
     # API for "doing something useful with the message"
-    def process_message(self, peer, mailfrom, rcpttos, data):
+    def process_message(self, peer, mailfrom, rcpttos, data, mail_options=None,rcpt_options=None):
         """Override this abstract method to handle messages from the client.
 
         peer is a tuple containing (ipaddr, port) of the client that made the
@@ -319,7 +319,7 @@ def module():
 
     class SchizoOpenRelay(SMTPServer):
 
-        def process_message(self, peer, mailfrom, rcpttos, data):
+        def process_message(self, peer, mailfrom, rcpttos, data, mail_options=None,rcpt_options=None):
             #setup the Log File
             log_to_file(mailoney.logpath+"/mail.log", peer[0], peer[1], '')
             log_to_file(mailoney.logpath+"/mail.log", peer[0], peer[1], '*' * 50)


### PR DESCRIPTION
the fake smtp server has the same issue as noticed below:

https://github.com/MISP/mail_to_misp/issues/13#issuecomment-577987466