### PR TITLE
fix: Update open_relay.py to fix uncaptured exception when trying to write byte 

### DIFF
--- a/modules/open_relay.py
+++ b/modules/open_relay.py
@@ -30,7 +30,7 @@ def or_module():
             logfile.write('Mail from: {}\n'.format(rcpttos[0]))
             logfile.write('Data:\n')
             logfile.write('\n')
-            logfile.write(data)
+            logfile.write(data.decode("utf-8"))
             logfile.close
 
     def run():


### PR DESCRIPTION
Fixes the issue in python 3.9:
error: uncaptured python exception, closing channel <smtpd.SMTPChannel connected ***:** at 0x7f4b47955ca0> (<class 'TypeError'>:write() argument must be str, not bytes [/usr/lib/python3.9/asyncore.py|read|83] [/usr/lib/python3.9/asyncore.py|handle_read_event|420] [/usr/lib/python3.9/asynchat.py|handle_read|171] [/usr/lib/python3.9/smtpd.py|found_terminator|386] [/home/azureuser/mailoney-master/modules/open_relay.py|process_message|33])