### PR TITLE
implement DATA command

### DIFF
--- a/mailoney/core.py
+++ b/mailoney/core.py
@@ -5,6 +5,7 @@ import socket
 import threading
 import logging
 import json
+import re
 import sys
 import argparse
 from time import strftime
@@ -105,12 +106,25 @@ class SMTPHoneypot:
             
             # Handle client commands
             error_count = 0
+            receiving_mail = False
+
             while error_count < 10:
                 try:
-                    request = client_socket.recv(4096).decode().strip().lower()
+                    raw_request = client_socket.recv(4096).decode()
+                    request = raw_request.strip().lower()
                     if not request:
                         break
                         
+                    if receiving_mail:
+                        session_log.append({"timestamp": strftime("%Y-%m-%d %H:%M:%S"), "direction": "in-body", "data": request})
+                        if re.search(r'(?:\r?\n|^)\.(?:\r?\n|$)', raw_request):
+                            response = "451 4.7.1 Try again later\n"
+                            client_socket.send(response.encode())
+                            session_log.append({"timestamp": strftime("%Y-%m-%d %H:%M:%S"), "direction": "out", "data": response})
+                            receiving_mail = False
+
+                        continue
+
                     session_log.append({"timestamp": strftime("%Y-%m-%d %H:%M:%S"), "direction": "in", "data": request})
                     logger.debug(f"Client: {request}")
                     
@@ -141,12 +155,20 @@ class SMTPHoneypot:
                         break
                         
                     # Handle other SMTP commands (simplistic simulation)
-                    elif request.startswith(('mail from:', 'rcpt to:', 'data')):
+                    elif request.startswith(('mail from:', 'rcpt to:')):
                         response = "250 2.1.0 OK\n"
                         client_socket.send(response.encode())
                         session_log.append({"timestamp": strftime("%Y-%m-%d %H:%M:%S"), "direction": "out", "data": response})
                         error_count = 0
-                        
+
+                    # Receive an e-mail
+                    elif request.startswith('data'):
+                        response = "354 End data with <CR><LF>.<CR><LF>\n"
+                        client_socket.send(response.encode())
+                        session_log.append({"timestamp": strftime("%Y-%m-%d %H:%M:%S"), "direction": "out", "data": response})
+                        receiving_mail = True
+                        error_count = 0
+
                     # Unknown command
                     else:
                         response = "502 5.5.2 Error: command not recognized\n"

--- a/src/mailoney/server.py
+++ b/src/mailoney/server.py
@@ -5,6 +5,7 @@ import socket
 import threading
 import logging
 import json
+import re
 from time import strftime
 from typing import Optional, Tuple, Dict, Any
 
@@ -102,12 +103,25 @@ class SMTPHoneypot:
             
             # Handle client commands
             error_count = 0
+            receiving_mail = False
+
             while error_count < 10:
                 try:
-                    request = client_socket.recv(4096).decode().strip().lower()
+                    raw_request = client_socket.recv(4096).decode()
+                    request = raw_request.strip().lower()
                     if not request:
                         break
                         
+                    if receiving_mail:
+                        session_log.append({"timestamp": strftime("%Y-%m-%d %H:%M:%S"), "direction": "in-body", "data": request})
+                        if re.search(r'(?:\r?\n|^)\.(?:\r?\n|$)', raw_request):
+                            response = "451 4.7.1 Try again later\n"
+                            client_socket.send(response.encode())
+                            session_log.append({"timestamp": strftime("%Y-%m-%d %H:%M:%S"), "direction": "out", "data": response})
+                            receiving_mail = False
+
+                        continue
+
                     session_log.append({"timestamp": strftime("%Y-%m-%d %H:%M:%S"), "direction": "in", "data": request})
                     logger.debug(f"Client: {request}")
                     
@@ -138,12 +152,20 @@ class SMTPHoneypot:
                         break
                         
                     # Handle other SMTP commands (simplistic simulation)
-                    elif request.startswith(('mail from:', 'rcpt to:', 'data')):
+                    elif request.startswith(('mail from:', 'rcpt to:')):
                         response = "250 2.1.0 OK\n"
                         client_socket.send(response.encode())
                         session_log.append({"timestamp": strftime("%Y-%m-%d %H:%M:%S"), "direction": "out", "data": response})
                         error_count = 0
-                        
+
+                    # Receive an e-mail
+                    elif request.startswith('data'):
+                        response = "354 End data with <CR><LF>.<CR><LF>\n"
+                        client_socket.send(response.encode())
+                        session_log.append({"timestamp": strftime("%Y-%m-%d %H:%M:%S"), "direction": "out", "data": response})
+                        receiving_mail = True
+                        error_count = 0
+
                     # Unknown command
                     else:
                         response = "502 5.5.2 Error: command not recognized\n"


### PR DESCRIPTION
This PR adds better support for `DATA` command. Instead of just replying `250 2.1.0 OK` and staying in the command mode, it responds with `354 End data with <CR><LF>.<CR><LF>`, receives and logs the e-mail, and only then returns to the command mode again.

Fixes #28