### PR TITLE
feat: implement SMTP DATA phase with optional filesystem storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ python main.py
 | `MAILONEY_BIND_PORT` | Port to listen on | 25 |
 | `MAILONEY_SERVER_NAME` | SMTP server name | mail.example.com |
 | `MAILONEY_DB_URL` | Database connection URL | sqlite:///mailoney.db |
+| `MAILONEY_MAIL_DIR` | When set, captured SMTP message bodies are written under this directory as `<YYYY-MM-DD>/<src-ip>/<session>.eml`. Unset = bodies stay inline in the session log. | (unset) |
 | `MAILONEY_LOG_LEVEL` | Logging level | INFO |
 
 ### Command-line Arguments
@@ -129,7 +130,31 @@ Available arguments:
 - `-p`, `--port`: Port to listen on
 - `-s`, `--server-name`: Server name to display in SMTP responses
 - `-d`, `--db-url`: Database URL
+- `--mail-dir`: Directory under which captured message bodies are written
 - `--log-level`: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+
+### Captured mail bodies
+
+Mailoney implements the SMTP `DATA` phase: when a client sends `DATA`, the
+server responds with `354 End data with <CR><LF>.<CR><LF>`, reads the
+message body until the standard terminator (or 1 MiB, whichever comes
+first), and replies `250 Ok`.
+
+Storage:
+
+- **Default** (`MAILONEY_MAIL_DIR` unset): the body is recorded inline in
+  the session log entry as `data` (UTF-8, with replacement on decode
+  errors).
+- **`MAILONEY_MAIL_DIR=/path`**: the body is written to
+  `<path>/<YYYY-MM-DD>/<src-ip>/<session-uuid>.eml` (mode `0640`,
+  directories `0750`) and the session log records the relative path
+  rather than the body contents. Recommended for production — keeps the
+  DB blob / event log small and lets bodies be handled directly by mail
+  / forensics tooling.
+
+Source IPs land in directory names with their colons intact (e.g.
+`2001:db8::1`). This is fine on Linux filesystems but breaks on Windows
+/ FAT bind mounts.
 
 ### Database Configuration
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ python main.py
 | `MAILONEY_BIND_PORT` | Port to listen on | 25 |
 | `MAILONEY_SERVER_NAME` | SMTP server name | mail.example.com |
 | `MAILONEY_DB_URL` | Database connection URL | sqlite:///mailoney.db |
-| `MAILONEY_MAIL_DIR` | When set, captured SMTP message bodies are written under this directory as `<YYYY-MM-DD>/<src-ip>/<session>.eml`. Unset = bodies stay inline in the session log. | (unset) |
+| `MAILONEY_MAIL_DIR` | When set, captured SMTP message bodies are written under this directory as `<YYYY-MM-DD>/<src-ip>/<session>.eml` and the session log records the relative path. Unset = bodies are discarded after their metadata (size, truncated flag) is recorded. Operators opt *in* to body retention. | (unset) |
 | `MAILONEY_LOG_LEVEL` | Logging level | INFO |
 
 ### Command-line Arguments
@@ -140,21 +140,20 @@ server responds with `354 End data with <CR><LF>.<CR><LF>`, reads the
 message body until the standard terminator (or 1 MiB, whichever comes
 first), and replies `250 Ok`.
 
-Storage:
+Storage is opt-in:
 
-- **Default** (`MAILONEY_MAIL_DIR` unset): the body is recorded inline in
-  the session log entry as `data` (UTF-8, with replacement on decode
-  errors).
+- **Default** (`MAILONEY_MAIL_DIR` unset): the body is discarded after
+  the session log records its metadata (`size`, `truncated`). The
+  operator gets a record that a body was received but no body content
+  is retained.
 - **`MAILONEY_MAIL_DIR=/path`**: the body is written to
   `<path>/<YYYY-MM-DD>/<src-ip>/<session-uuid>.eml` (mode `0640`,
-  directories `0750`) and the session log records the relative path
-  rather than the body contents. Recommended for production — keeps the
-  DB blob / event log small and lets bodies be handled directly by mail
-  / forensics tooling.
+  directories `0750`) and the session log records the relative path.
+  This is the only way to retain body content; the JSON log stream
+  never carries body bytes inline regardless of `MAILONEY_LOG_JSON`.
 
 Source IPs land in directory names with their colons intact (e.g.
-`2001:db8::1`). This is fine on Linux filesystems but breaks on Windows
-/ FAT bind mounts.
+`2001:db8::1`).
 
 ### Database Configuration
 

--- a/mailoney/config.py
+++ b/mailoney/config.py
@@ -22,7 +22,13 @@ class Settings(BaseSettings):
     
     # Database settings
     db_url: str = Field(default="sqlite:///mailoney.db")
-    
+
+    # Filesystem storage for captured mail bodies. Unset = bodies stay
+    # inline in the session log (DB blob / event JSON). When set, bodies
+    # are written under <mail_dir>/<YYYY-MM-DD>/<src-ip>/<session>.eml
+    # and the session log carries only the relative path.
+    mail_dir: Optional[str] = Field(default=None)
+
     # Logging settings
     log_level: str = Field(default="INFO")
     

--- a/mailoney/core.py
+++ b/mailoney/core.py
@@ -50,8 +50,10 @@ class SMTPHoneypot:
             bind_port: Port to listen on
             server_name: Server name to display in SMTP responses
             mail_dir: When set, captured message bodies are written to disk
-                under this directory; the session log records the relative
-                path. When None, bodies stay inline in the session log.
+                under this directory and the session log records the
+                relative path. When None, bodies are discarded after
+                metadata (size, truncated flag) is recorded — operators
+                opt *in* to body retention rather than out of it.
         """
         self.bind_ip = bind_ip
         self.bind_port = bind_port
@@ -228,12 +230,18 @@ class SMTPHoneypot:
                                 )
                                 body_entry["body_path"] = rel_path
                             except OSError as e:
+                                # Body storage was requested but failed. Log
+                                # the underlying error and surface it on the
+                                # record; do NOT inline the body bytes here —
+                                # if the operator set MAIL_DIR they
+                                # explicitly chose not to keep bodies in the
+                                # log/DB stream, and an error path should not
+                                # silently override that.
                                 logger.error(f"Failed to write mail body: {e}")
-                                # Fall back to inline so we don't lose the data.
-                                body_entry["data"] = body.decode("utf-8", errors="replace")
                                 body_entry["body_path_error"] = str(e)
-                        else:
-                            body_entry["data"] = body.decode("utf-8", errors="replace")
+                        # If self.mail_dir is unset, only metadata (size,
+                        # truncated) is retained. Operators opt in to body
+                        # retention by setting MAIL_DIR.
                         session_log.append(body_entry)
 
                         if terminator_found:

--- a/mailoney/core.py
+++ b/mailoney/core.py
@@ -1,19 +1,34 @@
 """
 Core functionality for the Mailoney SMTP Honeypot
 """
+import re
 import socket
 import threading
 import logging
 import json
 import sys
+import uuid
 import argparse
 from time import strftime
 from typing import Optional, Tuple, Dict, Any, List
 
 from .db import create_session, update_session_data, log_credential, init_db
 from .config import get_settings, configure_logging
+from .mail_storage import store_mail_body
 
 logger = logging.getLogger(__name__)
+
+# Cap on accumulated SMTP message body size. Real spam fits comfortably
+# under this; honeypot value drops fast above 1 MiB and unbounded reads
+# turn into a denial-of-service vector.
+MAX_MAIL_BODY_BYTES = 1_048_576
+
+# End-of-data terminator per RFC 5321 §4.1.1.4. ``\A`` lets an empty
+# body (``.\r\n`` immediately after the 354) terminate correctly. ``\r?``
+# tolerates LF-only clients.
+_DATA_TERMINATOR_RE = re.compile(rb"(?:\r?\n|\A)\.\r?\n")
+# Maximum bytes of overlap to keep when searching across recv() boundaries.
+_DATA_TERMINATOR_TAIL = 4
 
 class SMTPHoneypot:
     """
@@ -21,22 +36,27 @@ class SMTPHoneypot:
     """
     
     def __init__(
-        self, 
+        self,
         bind_ip: str = '0.0.0.0',
         bind_port: int = 25,
-        server_name: str = 'mail.example.com'
+        server_name: str = 'mail.example.com',
+        mail_dir: Optional[str] = None,
     ):
         """
         Initialize the SMTP honeypot server.
-        
+
         Args:
             bind_ip: IP address to bind to
             bind_port: Port to listen on
             server_name: Server name to display in SMTP responses
+            mail_dir: When set, captured message bodies are written to disk
+                under this directory; the session log records the relative
+                path. When None, bodies stay inline in the session log.
         """
         self.bind_ip = bind_ip
         self.bind_port = bind_port
         self.server_name = server_name
+        self.mail_dir = mail_dir
         self.socket = None
         self.ehlo_response = f'''250 {server_name}
 250-PIPELINING
@@ -86,14 +106,49 @@ class SMTPHoneypot:
             except Exception as e:
                 logger.error(f"Error accepting connection: {e}")
                 
+    def _receive_mail_body(
+        self,
+        recv_fn,
+        max_bytes: int = MAX_MAIL_BODY_BYTES,
+    ) -> Tuple[bytes, bool]:
+        """
+        Read SMTP message body bytes after a 354 response.
+
+        Reads via ``recv_fn(buffer_size)`` until the standard end-of-data
+        terminator (``<CRLF>.<CRLF>`` or the permissive ``\\n.\\n``) is
+        seen, or until ``max_bytes`` have been accumulated, or the peer
+        closes the connection.
+
+        The terminator search spans the chunk boundary by carrying over a
+        small tail from the previous read, so a terminator that lands
+        across two ``recv()`` calls is still detected.
+
+        Returns:
+            (body, terminator_found) — body excludes the terminator if
+            one was matched.
+        """
+        body = bytearray()
+        while len(body) < max_bytes:
+            remaining = max_bytes - len(body)
+            chunk = recv_fn(min(4096, remaining))
+            if not chunk:
+                break
+            search_start = max(0, len(body) - _DATA_TERMINATOR_TAIL)
+            body.extend(chunk)
+            m = _DATA_TERMINATOR_RE.search(bytes(body), search_start)
+            if m:
+                return bytes(body[:m.start()]), True
+        return bytes(body), False
+
     def _handle_client(self, client_socket: socket.socket, addr: Tuple[str, int]) -> None:
         """
         Handle client connection
-        
+
         Args:
             client_socket: Client socket
             addr: Client address tuple (ip, port)
         """
+        session_uuid = str(uuid.uuid4())
         session_record = create_session(
             addr[0], addr[1], self.server_name,
             dest_ip=self.bind_ip,
@@ -144,13 +199,57 @@ class SMTPHoneypot:
                         session_log.append({"timestamp": strftime("%Y-%m-%d %H:%M:%S"), "direction": "out", "data": response})
                         break
                         
-                    # Handle other SMTP commands (simplistic simulation)
-                    elif request.startswith(('mail from:', 'rcpt to:', 'data')):
+                    # MAIL FROM: / RCPT TO: — accept envelope, no body involved.
+                    elif request.startswith(('mail from:', 'rcpt to:')):
                         response = "250 2.1.0 OK\n"
                         client_socket.send(response.encode())
                         session_log.append({"timestamp": strftime("%Y-%m-%d %H:%M:%S"), "direction": "out", "data": response})
                         error_count = 0
-                        
+
+                    # DATA — enter body-receive mode, read until terminator
+                    # or size cap, then return to command mode.
+                    elif request.startswith('data'):
+                        invitation = "354 End data with <CR><LF>.<CR><LF>\n"
+                        client_socket.send(invitation.encode())
+                        session_log.append({"timestamp": strftime("%Y-%m-%d %H:%M:%S"), "direction": "out", "data": invitation})
+
+                        body, terminator_found = self._receive_mail_body(client_socket.recv)
+
+                        body_entry: Dict[str, Any] = {
+                            "timestamp": strftime("%Y-%m-%d %H:%M:%S"),
+                            "direction": "mail-body",
+                            "size": len(body),
+                            "truncated": not terminator_found,
+                        }
+                        if self.mail_dir:
+                            try:
+                                rel_path = store_mail_body(
+                                    self.mail_dir, addr[0], session_uuid, body,
+                                )
+                                body_entry["body_path"] = rel_path
+                            except OSError as e:
+                                logger.error(f"Failed to write mail body: {e}")
+                                # Fall back to inline so we don't lose the data.
+                                body_entry["data"] = body.decode("utf-8", errors="replace")
+                                body_entry["body_path_error"] = str(e)
+                        else:
+                            body_entry["data"] = body.decode("utf-8", errors="replace")
+                        session_log.append(body_entry)
+
+                        if terminator_found:
+                            response = "250 2.0.0 Ok\n"
+                        elif len(body) >= MAX_MAIL_BODY_BYTES:
+                            response = "552 5.3.4 Message size limit exceeded\n"
+                        else:
+                            # Peer closed mid-body. Connection is effectively gone;
+                            # send a polite close and break.
+                            response = "421 4.4.2 Connection closed\n"
+                        client_socket.send(response.encode())
+                        session_log.append({"timestamp": strftime("%Y-%m-%d %H:%M:%S"), "direction": "out", "data": response})
+                        if not terminator_found:
+                            break
+                        error_count = 0
+
                     # Unknown command
                     else:
                         response = "502 5.5.2 Error: command not recognized\n"
@@ -209,18 +308,28 @@ def parse_args() -> argparse.Namespace:
     )
     
     parser.add_argument(
-        '-d', '--db-url', 
+        '-d', '--db-url',
         default=get_settings().db_url,
         help='Database URL (default: sqlite:///mailoney.db)'
     )
-    
+
     parser.add_argument(
-        '--log-level', 
+        '--mail-dir',
+        default=get_settings().mail_dir,
+        help=(
+            'Directory under which captured SMTP message bodies are written '
+            'as <YYYY-MM-DD>/<src-ip>/<session>.eml. '
+            'When unset, bodies stay inline in the session log.'
+        )
+    )
+
+    parser.add_argument(
+        '--log-level',
         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
         default=get_settings().log_level,
         help='Log level'
     )
-    
+
     return parser.parse_args()
 
 
@@ -259,7 +368,8 @@ def run_server() -> None:
         server = SMTPHoneypot(
             bind_ip=args.ip,
             bind_port=args.port,
-            server_name=args.server_name
+            server_name=args.server_name,
+            mail_dir=args.mail_dir,
         )
         
         logger.info(f"Starting SMTP Honeypot on {args.ip}:{args.port}")

--- a/mailoney/mail_storage.py
+++ b/mailoney/mail_storage.py
@@ -10,9 +10,7 @@ The session record in the DB and the event log carry the *relative* path
 keeping operational data small and letting bodies be handled like any
 other file by mail/forensics tooling.
 
-IPv6 source IPs land in folder names with their colons intact. This is
-fine on Linux filesystems but will break Windows / FAT / exFAT bind
-mounts; deploy on Linux.
+IPv6 source IPs land in folder names with their colons intact.
 """
 import logging
 import os

--- a/mailoney/mail_storage.py
+++ b/mailoney/mail_storage.py
@@ -1,0 +1,78 @@
+"""
+Filesystem storage for captured SMTP message bodies.
+
+When ``MAILONEY_MAIL_DIR`` is set, each captured body is written to:
+
+    <MAIL_DIR>/<YYYY-MM-DD>/<src-ip>/<session-uuid>.eml
+
+The session record in the DB and the event log carry the *relative* path
+(e.g. ``2026-05-09/2001:db8::1/abc-...eml``) instead of the body bytes,
+keeping operational data small and letting bodies be handled like any
+other file by mail/forensics tooling.
+
+IPv6 source IPs land in folder names with their colons intact. This is
+fine on Linux filesystems but will break Windows / FAT / exFAT bind
+mounts; deploy on Linux.
+"""
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_ip_segment(src_ip: str) -> str:
+    """Render a source IP as a directory name, defensively.
+
+    IPv4 and IPv6 literals (with optional %zone) only contain digits,
+    letters, ``.``, ``:``, ``%``, and ``-``. Whitelist those and drop
+    anything else — defence in depth against malformed peer addresses,
+    not a strict validator.
+    """
+    cleaned = "".join(c for c in src_ip if c.isalnum() or c in ".:%_-")
+    return cleaned or "unknown"
+
+
+def _today_segment() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def store_mail_body(
+    mail_dir: str,
+    src_ip: str,
+    session_uuid: str,
+    body: bytes,
+) -> str:
+    """
+    Persist a captured mail body to disk.
+
+    Args:
+        mail_dir: Root directory (e.g. value of MAILONEY_MAIL_DIR).
+        src_ip: Source IP literal of the SMTP client.
+        session_uuid: Per-session identifier; used as the filename stem.
+        body: Raw body bytes as captured between ``354`` and the
+            ``<CRLF>.<CRLF>`` terminator (terminator already stripped).
+
+    Returns:
+        The path to the written file, relative to ``mail_dir``.
+        Callers should record this in the session log so consumers know
+        where to find the body.
+    """
+    root = Path(mail_dir)
+    rel_dir = Path(_today_segment()) / _safe_ip_segment(src_ip)
+    abs_dir = root / rel_dir
+    abs_dir.mkdir(parents=True, exist_ok=True, mode=0o750)
+
+    rel_path = rel_dir / f"{session_uuid}.eml"
+    abs_path = root / rel_path
+
+    # Open with O_CREAT|O_WRONLY|O_EXCL is safer (rejects collisions) but
+    # session UUIDs are unique enough; use plain write for simplicity.
+    with open(abs_path, "wb") as f:
+        f.write(body)
+    os.chmod(abs_path, 0o640)
+
+    logger.info(f"Stored mail body ({len(body)} bytes) at {rel_path}")
+    return str(rel_path)

--- a/tests/test_data_handling.py
+++ b/tests/test_data_handling.py
@@ -1,0 +1,165 @@
+"""
+Tests for the SMTP DATA-phase implementation:
+
+  * the chunked body reader (`SMTPHoneypot._receive_mail_body`)
+  * the filesystem storage helper (`mail_storage.store_mail_body`)
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+from mailoney.core import (
+    MAX_MAIL_BODY_BYTES,
+    SMTPHoneypot,
+)
+from mailoney import mail_storage
+
+
+def _make_recv(*chunks: bytes):
+    """Build a recv-shaped callable that yields the given chunks in order.
+
+    Honours the buffer-size contract: if a scripted chunk is larger than
+    the requested size, returns the head and queues the tail for the next
+    call.
+    """
+    queue = list(chunks)
+
+    def _recv(size: int) -> bytes:
+        if not queue:
+            return b""
+        chunk = queue.pop(0)
+        if len(chunk) <= size:
+            return chunk
+        queue.insert(0, chunk[size:])
+        return chunk[:size]
+
+    return _recv
+
+
+@pytest.fixture
+def honeypot():
+    return SMTPHoneypot(bind_ip="127.0.0.1", bind_port=8025)
+
+
+def test_receive_body_single_chunk(honeypot):
+    body, found = honeypot._receive_mail_body(
+        _make_recv(b"Subject: hi\r\n\r\nHello world\r\n.\r\n")
+    )
+    assert found is True
+    assert body == b"Subject: hi\r\n\r\nHello world"
+
+
+def test_receive_body_multiple_chunks(honeypot):
+    """The reader must reassemble across recv() boundaries."""
+    body, found = honeypot._receive_mail_body(
+        _make_recv(
+            b"Subject: split\r\n\r\nFirst half ",
+            b"second half\r\n.\r\n",
+        )
+    )
+    assert found is True
+    assert body == b"Subject: split\r\n\r\nFirst half second half"
+
+
+def test_receive_body_terminator_split_across_boundary(honeypot):
+    """`\\r\\n.\\r\\n` arriving in two recv() calls is still detected."""
+    body, found = honeypot._receive_mail_body(
+        _make_recv(
+            b"hello world\r\n",
+            b".\r\n",
+        )
+    )
+    assert found is True
+    assert body == b"hello world"
+
+
+def test_receive_body_permissive_terminator(honeypot):
+    """`\\n.\\n` (LF-only) is also recognised."""
+    body, found = honeypot._receive_mail_body(
+        _make_recv(b"loose body\n.\n")
+    )
+    assert found is True
+    assert body == b"loose body"
+
+
+def test_receive_body_empty(honeypot):
+    """A body that's just the terminator (empty message) returns empty bytes."""
+    body, found = honeypot._receive_mail_body(_make_recv(b".\r\n"))
+    assert found is True
+    assert body == b""
+
+
+def test_receive_body_peer_close_without_terminator(honeypot):
+    """Peer disconnects mid-body — return what we have, found=False."""
+    body, found = honeypot._receive_mail_body(_make_recv(b"truncated"))
+    assert found is False
+    assert body == b"truncated"
+
+
+def test_receive_body_size_cap_truncates(honeypot):
+    """At the cap, recv loop stops, found=False, body is exactly cap-sized."""
+    payload = b"x" * 200_000  # > a recv buffer, < the cap
+    body, found = honeypot._receive_mail_body(
+        _make_recv(payload * 10),  # 2 MB total — exceeds 1 MB cap
+        max_bytes=500_000,
+    )
+    assert found is False
+    assert len(body) == 500_000
+
+
+def test_receive_body_command_like_content_is_not_interpreted(honeypot):
+    """Bytes inside the body that look like SMTP commands stay opaque."""
+    body, found = honeypot._receive_mail_body(
+        _make_recv(b"This body contains QUIT and EHLO foo\r\n.\r\n")
+    )
+    assert found is True
+    assert b"QUIT" in body
+    assert b"EHLO" in body
+
+
+# --- mail_storage --------------------------------------------------------
+
+
+def test_store_mail_body_writes_file_with_expected_layout(tmp_path):
+    rel = mail_storage.store_mail_body(
+        str(tmp_path), "192.0.2.1", "abc-123", b"hello body\r\n",
+    )
+    abs_path = tmp_path / rel
+    assert abs_path.exists()
+    assert abs_path.read_bytes() == b"hello body\r\n"
+    # YYYY-MM-DD / src-ip / uuid.eml
+    parts = Path(rel).parts
+    assert len(parts) == 3
+    assert parts[1] == "192.0.2.1"
+    assert parts[2] == "abc-123.eml"
+
+
+def test_store_mail_body_preserves_ipv6_colons(tmp_path):
+    rel = mail_storage.store_mail_body(
+        str(tmp_path), "2001:db8::1", "uuid-x", b"x",
+    )
+    parts = Path(rel).parts
+    assert parts[1] == "2001:db8::1"
+    assert (tmp_path / rel).exists()
+
+
+def test_store_mail_body_strips_unsafe_characters(tmp_path):
+    """Garbage in the IP gets dropped, but a path is still produced."""
+    rel = mail_storage.store_mail_body(
+        str(tmp_path), "../../../etc/passwd", "uuid-y", b"bytes",
+    )
+    parts = Path(rel).parts
+    # No path traversal should survive.
+    assert ".." not in parts
+    assert "etc" not in parts
+    assert (tmp_path / rel).exists()
+
+
+def test_store_mail_body_sets_restrictive_mode(tmp_path):
+    rel = mail_storage.store_mail_body(
+        str(tmp_path), "10.0.0.1", "uuid-z", b"x",
+    )
+    abs_path = tmp_path / rel
+    mode = os.stat(abs_path).st_mode & 0o777
+    assert mode == 0o640


### PR DESCRIPTION
hey, saw #29 and find the idea nice but needs some tune, therefore a superseded PR with similar base idea.

Mailoney currently lumps DATA together with MAIL FROM / RCPT TO in a single elif and replies `250 OK` to all three. It never enters body-receive mode. Whatever the client sends after DATA gets pulled by the regular `recv()` loop, lowercased, stripped, and treated as SMTP commands — most fall through to "command not recognized" until the error counter trips. The mail body is effectively lost.

### so, this pr contains: 

- `DATA` now replies with `354 End data with <CR><LF>.<CR><LF>` and  enters body-receive mode
- `_receive_mail_body()` reads via the client socket's `recv` until  `<CRLF>.<CRLF>` (or the permissive `\n.\n`) appears, or until a 1 MiB size cap is hit, or the peer closes
- The terminator search spans the chunk boundary by carrying over a  4-byte tail per iteration; a `<CRLF>.<CRLF>` split across two  `recv()` calls is still detected
- After the body:
  - terminator matched → `250 2.0.0 Ok`
  - size cap reached → `552 5.3.4 Message size limit exceeded`
  - peer closed mid-body → `421 4.4.2 Connection closed` + break
- The reply is `250 OK`, not `451 Try again later` as in #29. The  intent is to make the attacker think the message went through, so  they don't retry and double-store the same content.
- Empty bodies (`.\r\n` immediately after the 354) terminate  correctly via a `\A`-anchored regex
- Body bytes are kept raw — no `.strip().lower()` — so headers,  base64 attachments, and non-ASCII text survive intact

### Optional filesystem storage

`MAILONEY_MAIL_DIR` enables on-disk body capture:

```
<MAIL_DIR>/<YYYY-MM-DD>/<src-ip>/<session-uuid>.eml
```

When set:
- Body bytes are written verbatim (mode `0640`, dirs `0750`)
- The session log records the relative path, not the body contents
- Operationally simpler — `.eml` files open in any mail reader,  scan cleanly with `clamscan`, `oletools`, etc.

When unset, the truncated body/size is mentioned in the log.

### Tests
`tests/test_data_handling.py` covers:
- Single-chunk body, multi-chunk body, terminator split across boundary
- Permissive `\n.\n` terminator
- Empty body
- Peer disconnect mid-body
- Size cap truncation
- Command-like bytes inside the body (must not be parsed as commands)
- Filesystem storage: layout, IPv6 paths (Linux), unsafe-character
  stripping, file mode `0640`

### Todo
- [ ]  Bubmp version
- [x] Readme update
- [ ] ..?