### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/mailoney/__init__.py
+++ b/mailoney/__init__.py
@@ -2,7 +2,7 @@
 Mailoney - A Simple SMTP Honeypot with database logging
 """
 __author__ = 'awhitehatter'
-__version__ = '2.1.0'
+__version__ = '2.2.0'
 
 # Import key components to make them available at package level
 from .db import init_db

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mailoney"
-version = "2.1.0"
+version = "2.2.0"
 authors = [
     { name = "phin3has", email = "phin3has@protonmail.com" }
 ]


### PR DESCRIPTION
Bumps `pyproject.toml` and `mailoney/__init__.py` from 2.1.0 to 2.2.0.

This release covers the two features merged since 2.1.0:
- #31 — IPv6 and dual-stack SMTP bind support
- #32 — SMTP `DATA`-phase implementation with optional filesystem storage (closes #28)

#32's own TODO checklist left the version bump unchecked; this PR completes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)