### PR TITLE
fix: point console script at mailoney:run_server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 "Bug Tracker" = "https://github.com/phin3has/mailoney/issues"
 
 [project.scripts]
-mailoney = "main:main"
+mailoney = "mailoney:run_server"
 
 [tool.pytest.ini_options]
 addopts = "-ra -q"


### PR DESCRIPTION
## Problem

`pyproject.toml` declared:

```toml
[project.scripts]
mailoney = "main:main"
```

This resolves to a `main()` callable in the top-level `main` module — but no such function exists. `main.py` only calls `run_server()` under an `if __name__ == "__main__"` guard, which a console-script entry point does **not** trigger (it imports the module and calls the named attribute). So after `pip install`, the `mailoney` command crashed on launch.

## Fix

Repoint the entry to `mailoney:run_server`, which the package already exports — `mailoney/__init__.py` does `from .core import SMTPHoneypot, run_server`. This also removes the console script's dependency on the top-level `main.py` shim.

```diff
-mailoney = "main:main"
+mailoney = "mailoney:run_server"
```

## Verification

```
$ pip install -e .
$ mailoney --help
usage: mailoney [-h] [-i IP] [-p PORT] [-s SERVER_NAME] [-d DB_URL]
                [--mail-dir MAIL_DIR]
                [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
...
```

Resolves and runs cleanly. `python main.py` is unaffected.

Fixes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)