### PR TITLE
fix: per-connection inactivity timeout (slow-loris protection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ python main.py
 | `MAILONEY_BIND_IP` | IP address to bind to | 0.0.0.0 |
 | `MAILONEY_BIND_PORT` | Port to listen on | 25 |
 | `MAILONEY_SERVER_NAME` | SMTP server name | mail.example.com |
+| `MAILONEY_CONN_TIMEOUT` | Per-connection inactivity timeout (seconds). A client that sends nothing for this long is dropped, so slow-loris connections cannot pin handler threads. `0` disables it. | 30 |
 | `MAILONEY_DB_URL` | Database connection URL | sqlite:///mailoney.db |
 | `MAILONEY_MAIL_DIR` | When set, captured SMTP message bodies are written under this directory as `<YYYY-MM-DD>/<src-ip>/<session>.eml` and the session log records the relative path. Unset = bodies are discarded after their metadata (size, truncated flag) is recorded. Operators opt *in* to body retention. | (unset) |
 | `MAILONEY_LOG_LEVEL` | Logging level | INFO |
@@ -129,6 +130,7 @@ Available arguments:
 - `-i`, `--ip`: IP address to bind to
 - `-p`, `--port`: Port to listen on
 - `-s`, `--server-name`: Server name to display in SMTP responses
+- `--conn-timeout`: Per-connection inactivity timeout in seconds (0 disables it)
 - `-d`, `--db-url`: Database URL
 - `--mail-dir`: Directory under which captured message bodies are written
 - `--log-level`: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)

--- a/mailoney/config.py
+++ b/mailoney/config.py
@@ -19,7 +19,13 @@ class Settings(BaseSettings):
     bind_ip: str = Field(default="0.0.0.0")
     bind_port: int = Field(default=25)
     server_name: str = Field(default="mail.example.com")
-    
+
+    # Per-connection inactivity timeout in seconds. A client that neither
+    # sends a command nor advances the DATA body within this window is
+    # dropped, so slow-loris connections cannot pin handler threads.
+    # 0 or negative disables the timeout (not recommended).
+    conn_timeout: int = Field(default=30)
+
     # Database settings
     db_url: str = Field(default="sqlite:///mailoney.db")
 

--- a/mailoney/core.py
+++ b/mailoney/core.py
@@ -30,6 +30,12 @@ _DATA_TERMINATOR_RE = re.compile(rb"(?:\r?\n|\A)\.\r?\n")
 # Maximum bytes of overlap to keep when searching across recv() boundaries.
 _DATA_TERMINATOR_TAIL = 4
 
+# Per-connection inactivity timeout, in seconds. Bounds how long a single
+# client can hold a handler thread (and socket) while sending nothing —
+# without it a slow-loris client pins threads indefinitely. A value <= 0
+# disables the timeout.
+DEFAULT_CONN_TIMEOUT = 30
+
 class SMTPHoneypot:
     """
     SMTP Honeypot Server class
@@ -41,6 +47,7 @@ class SMTPHoneypot:
         bind_port: int = 25,
         server_name: str = 'mail.example.com',
         mail_dir: Optional[str] = None,
+        conn_timeout: int = DEFAULT_CONN_TIMEOUT,
     ):
         """
         Initialize the SMTP honeypot server.
@@ -54,11 +61,16 @@ class SMTPHoneypot:
                 relative path. When None, bodies are discarded after
                 metadata (size, truncated flag) is recorded — operators
                 opt *in* to body retention rather than out of it.
+            conn_timeout: Per-connection inactivity timeout in seconds. A
+                client that sends nothing for this long is dropped, so a
+                slow-loris client cannot pin a handler thread. A value
+                <= 0 disables the timeout.
         """
         self.bind_ip = bind_ip
         self.bind_port = bind_port
         self.server_name = server_name
         self.mail_dir = mail_dir
+        self.conn_timeout = conn_timeout
         self.socket = None
         self.ehlo_response = f'''250 {server_name}
 250-PIPELINING
@@ -137,7 +149,8 @@ class SMTPHoneypot:
         Reads via ``recv_fn(buffer_size)`` until the standard end-of-data
         terminator (``<CRLF>.<CRLF>`` or the permissive ``\\n.\\n``) is
         seen, or until ``max_bytes`` have been accumulated, or the peer
-        closes the connection.
+        closes the connection, or ``recv_fn`` raises ``socket.timeout``
+        (the client stalled mid-body).
 
         The terminator search spans the chunk boundary by carrying over a
         small tail from the previous read, so a terminator that lands
@@ -145,12 +158,18 @@ class SMTPHoneypot:
 
         Returns:
             (body, terminator_found) — body excludes the terminator if
-            one was matched.
+            one was matched. ``terminator_found`` is False for a peer
+            close, a size-cap hit, or a recv timeout (truncated body).
         """
         body = bytearray()
         while len(body) < max_bytes:
             remaining = max_bytes - len(body)
-            chunk = recv_fn(min(4096, remaining))
+            try:
+                chunk = recv_fn(min(4096, remaining))
+            except socket.timeout:
+                # Client stalled mid-body. Return what arrived as a
+                # truncated message rather than blocking the thread.
+                break
             if not chunk:
                 break
             search_start = max(0, len(body) - _DATA_TERMINATOR_TAIL)
@@ -175,7 +194,15 @@ class SMTPHoneypot:
             dest_port=self.bind_port
         )
         session_log = []
-        
+
+        # Bound the lifetime of an idle connection. With a timeout set,
+        # recv()/send() raise socket.timeout after this many seconds of
+        # inactivity, so a client that connects and then sends nothing
+        # (slow-loris) cannot pin this handler thread forever. A value
+        # <= 0 leaves the socket in its default blocking mode.
+        if self.conn_timeout and self.conn_timeout > 0:
+            client_socket.settimeout(self.conn_timeout)
+
         try:
             # Send banner
             banner = f"220 {self.server_name} ESMTP Service Ready\n"
@@ -283,6 +310,22 @@ class SMTPHoneypot:
                         session_log.append({"timestamp": strftime("%Y-%m-%d %H:%M:%S"), "direction": "out", "data": response})
                         error_count += 1
                         
+                except socket.timeout:
+                    # Idle longer than conn_timeout. Drop the connection
+                    # so the handler thread is freed; the 421 reply is
+                    # best-effort since the peer may already be gone.
+                    logger.info(
+                        f"Connection from {addr[0]}:{addr[1]} timed out after "
+                        f"{self.conn_timeout}s of inactivity"
+                    )
+                    timeout_reply = "421 4.4.2 Connection timed out\n"
+                    try:
+                        client_socket.send(timeout_reply.encode())
+                    except OSError:
+                        pass
+                    session_log.append({"timestamp": strftime("%Y-%m-%d %H:%M:%S"), "direction": "out", "data": timeout_reply})
+                    break
+
                 except Exception as e:
                     logger.error(f"Error handling client request: {e}")
                     error_count += 1
@@ -350,6 +393,17 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        '--conn-timeout',
+        type=int,
+        default=get_settings().conn_timeout,
+        help=(
+            'Per-connection inactivity timeout in seconds. A client that '
+            'sends nothing for this long is dropped, bounding slow-loris '
+            'style abuse. 0 disables it. (default: 30)'
+        )
+    )
+
+    parser.add_argument(
         '--log-level',
         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
         default=get_settings().log_level,
@@ -396,6 +450,7 @@ def run_server() -> None:
             bind_port=args.port,
             server_name=args.server_name,
             mail_dir=args.mail_dir,
+            conn_timeout=args.conn_timeout,
         )
         
         logger.info(f"Starting SMTP Honeypot on {args.ip}:{args.port}")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,8 +3,9 @@ Tests for the core module
 """
 import pytest
 import socket
+import threading
 from unittest.mock import patch, MagicMock
-from mailoney.core import SMTPHoneypot
+from mailoney.core import SMTPHoneypot, DEFAULT_CONN_TIMEOUT
 
 @pytest.fixture
 def smtp_honeypot():
@@ -60,3 +61,50 @@ def test_smtp_honeypot_start(mock_socket, smtp_honeypot):
     finally:
         # Restore the original method
         smtp_honeypot._accept_connections = original_method
+
+
+def test_conn_timeout_defaults(smtp_honeypot):
+    """conn_timeout defaults to DEFAULT_CONN_TIMEOUT and is overridable."""
+    assert smtp_honeypot.conn_timeout == DEFAULT_CONN_TIMEOUT
+    assert SMTPHoneypot(conn_timeout=5).conn_timeout == 5
+
+
+def test_idle_connection_times_out():
+    """A client that connects and then sends nothing must be dropped after
+    conn_timeout, freeing the handler thread (slow-loris protection).
+
+    Without the timeout, _handle_client blocks forever on recv() and the
+    thread never exits.
+    """
+    server_sock, client_sock = socket.socketpair()
+    honeypot = SMTPHoneypot(
+        bind_ip="127.0.0.1", bind_port=8025, conn_timeout=1
+    )
+
+    handler = threading.Thread(
+        target=honeypot._handle_client,
+        args=(server_sock, ("203.0.113.7", 54321)),
+    )
+    handler.start()
+
+    # Client reads the banner, then deliberately sends nothing at all.
+    banner = client_sock.recv(1024)
+    assert banner.startswith(b"220 ")
+
+    # The handler must exit on its own well within the join window.
+    handler.join(timeout=5)
+    assert not handler.is_alive(), "handler thread did not exit after timeout"
+
+    # It should have sent a 421 timeout reply before closing the socket.
+    client_sock.settimeout(2)
+    tail = b""
+    try:
+        while True:
+            chunk = client_sock.recv(1024)
+            if not chunk:
+                break
+            tail += chunk
+    except socket.timeout:
+        pass
+    assert b"421" in tail
+    client_sock.close()

--- a/tests/test_data_handling.py
+++ b/tests/test_data_handling.py
@@ -5,6 +5,7 @@ Tests for the SMTP DATA-phase implementation:
   * the filesystem storage helper (`mail_storage.store_mail_body`)
 """
 import os
+import socket
 from pathlib import Path
 
 import pytest
@@ -33,6 +34,21 @@ def _make_recv(*chunks: bytes):
             return chunk
         queue.insert(0, chunk[size:])
         return chunk[:size]
+
+    return _recv
+
+
+def _make_recv_then_timeout(*chunks: bytes):
+    """A recv-shaped callable that yields the given chunks, then raises
+    ``socket.timeout`` — simulating a client that stalls mid-body once the
+    socket has an inactivity timeout set.
+    """
+    queue = list(chunks)
+
+    def _recv(size: int) -> bytes:
+        if queue:
+            return queue.pop(0)
+        raise socket.timeout()
 
     return _recv
 
@@ -116,6 +132,18 @@ def test_receive_body_command_like_content_is_not_interpreted(honeypot):
     assert found is True
     assert b"QUIT" in body
     assert b"EHLO" in body
+
+
+def test_receive_body_recv_timeout_truncates(honeypot):
+    """A recv() timeout mid-body yields a truncated result, not a hang.
+
+    Without this the handler thread blocks forever on a stalled client.
+    """
+    body, found = honeypot._receive_mail_body(
+        _make_recv_then_timeout(b"partial body before the client stalled")
+    )
+    assert found is False
+    assert body == b"partial body before the client stalled"
 
 
 # --- mail_storage --------------------------------------------------------


### PR DESCRIPTION
## Problem

`_handle_client` and `_receive_mail_body` (`mailoney/core.py`) looped on `recv()` with no socket timeout. Since the honeypot runs **one thread per connection**, a client that connects and then sends nothing — or stalls mid-`DATA` body — keeps its handler thread blocked forever. A handful of such connections exhausts the server. Classic slow-loris.

The 1 MiB `MAX_MAIL_BODY_BYTES` cap added in #32 bounds *volume* but not *time* — a slow trickle never reaches it.

Note this gap predates #32: the original command loop has the same unbounded `recv()`. This PR fixes **both** paths.

## Changes

- New **`conn_timeout`** setting — `MAILONEY_CONN_TIMEOUT` env var / `--conn-timeout` CLI arg, **default 30s**, `0` (or negative) disables it.
- `_handle_client` calls `client_socket.settimeout(conn_timeout)` on the accepted socket, so `recv()`/`send()` raise `socket.timeout` after the idle window.
- The command loop catches `socket.timeout`, sends a best-effort `421 4.4.2 Connection timed out`, logs it, and closes the connection.
- `_receive_mail_body` catches `socket.timeout` mid-body and returns the partial body with `terminator_found=False` — recorded in the session log as `truncated: true` — instead of hanging.

## Tests

**25 passing**, 3 new:
- `test_receive_body_recv_timeout_truncates` — a recv timeout mid-body yields a truncated result, not a hang
- `test_idle_connection_times_out` — an idle `socketpair` connection is dropped and the handler thread exits (sends `421`)
- `test_conn_timeout_defaults` — default and override

## Acceptance criteria (from #36)

- [x] A client that connects and stalls is dropped after the timeout
- [x] A client that stalls mid-`DATA` body is dropped; partial body recorded with `truncated: true`
- [x] Normal fast clients are unaffected (full suite green)

## Out of scope — separate pre-existing issue

While updating docs I found `.env.example` is **untracked**: `.gitignore` has `.env.*`, which excludes the example file the project means to ship. The README env-var table is updated here (that's the canonical doc); fixing `.gitignore` + committing `.env.example` is left as its own change. Happy to open an issue.

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)