### PR TITLE
chore: track .env.example (was excluded by .gitignore)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Mailoney Configuration Example
+# Copy this file to .env and modify as needed
+
+# Server settings
+MAILONEY_BIND_IP=0.0.0.0
+MAILONEY_BIND_PORT=25
+MAILONEY_SERVER_NAME=mail.example.com
+
+# Per-connection inactivity timeout in seconds (0 disables it)
+MAILONEY_CONN_TIMEOUT=30
+
+# Database settings
+# Uncomment and modify for PostgreSQL
+# MAILONEY_DB_URL=postgresql://postgres:postgres@localhost:5432/mailoney
+
+# For SQLite (default)
+MAILONEY_DB_URL=sqlite:///mailoney.db
+
+# Captured mail bodies
+# When set, SMTP message bodies are written to disk under this directory
+# as <YYYY-MM-DD>/<src-ip>/<session>.eml. Unset = bodies are discarded
+# after their metadata (size, truncated flag) is recorded.
+# MAILONEY_MAIL_DIR=/var/lib/mailoney/mail
+
+# Logging
+MAILONEY_LOG_LEVEL=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ logs/
 # Environment variables
 .env
 .env.*
+# ...but the example config is meant to be committed.
+!.env.example
 
 # Docker
 .docker/


### PR DESCRIPTION
## Problem

The repo ships a `.env.example` template, and the README's Local Installation flow implies users copy it to `.env`. But `.gitignore` had:

```
.env
.env.*
```

`.env.*` matches `.env.example`, so the file was **never tracked** — a fresh `git clone` doesn't include it. (`git check-ignore .env.example` confirmed the match.) Surfaced while documenting `MAILONEY_CONN_TIMEOUT` in #38.

## Fix

Add a negation so local env files stay ignored but the example is tracked:

```diff
 .env
 .env.*
+# ...but the example config is meant to be committed.
+!.env.example
```

Verified: `.env.example` is no longer ignored, `.env` still is.

Then commit `.env.example` itself, refreshed to cover settings added since it was last edited:
- `MAILONEY_CONN_TIMEOUT` (from #38)
- `MAILONEY_MAIL_DIR` (from #32, commented out — default is unset)

## Note on ordering

`.env.example` here references `MAILONEY_CONN_TIMEOUT`, which is introduced by #38. It's documentation only and harmless if this merges first (`Settings` uses `extra="ignore"`), but merging #38 first keeps things tidy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)